### PR TITLE
Update tagline

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-_“Bests for documenting software.”_
+_“Best practices for documenting software.”_
 
 ### Download
 

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-_“Best practice templates and writing instructions for documenting open source software.”_
+_“Bests for documenting software.”_
 
 ### Download
 


### PR DESCRIPTION
Bug #38 
Update tagline from:
“Best practice templates and writing instructions for documenting open source software.”
to
“Best practices for documenting software.”