### PR TITLE
Add community processes 2.0: 

### DIFF
--- a/community.md
+++ b/community.md
@@ -4,10 +4,12 @@ layout: default
 
 ## Community
 
-
+*   [Contact us](contact.html)
 *   [Contribute](contribute.html)
-*   [Code of Conduct](https://github.com/thegooddocsproject/governance/blob/master/CodeOfConduct.md)
-*   [Contact Us](contact.html)
-*   [Roles](roles.html)
-*   [Decisions](decisions.html)
-*   [Decision Log](decisionlog.html)
+*   [Roles and responsibilities](roles.html)
+* Decisions
+    *   [Voting process](decisions.html)
+    *   [Prioritization guidelines and principles](prioritization.html)
+    *   [Proposal selection process](proposal-selection.html)
+    *   [Decision log](decisionlog.html)
+*   [Code of conduct](https://github.com/thegooddocsproject/governance/blob/master/CodeOfConduct.md)

--- a/decisions.md
+++ b/decisions.md
@@ -32,7 +32,7 @@ Should a decision:
 *   Be strategic or impact many within the project,
 *   Be contentious, and after discussion at least one member is still strongly against the motion, by continuing to vote -1,
 
-then a motion should be raised as an email thread on our [general email list](https://thegooddocsproject.groups.io/g/main). The title should start: “Motion: …”
+then a motion should be raised as an email thread on our [general email list](https://thegooddocsproject.groups.io/g/main). The subject line should start: “Motion: …”
 
 All community members are encouraged to vote to demonstrate community support, however contentious motions will only count votes from PSC members.
 

--- a/decisions.md
+++ b/decisions.md
@@ -2,23 +2,43 @@
 layout: default
 ---
 
-## The Good Docs Project Decisions
+# Decisions
 
-### Criteria for Decision Making
+This page describes the decision making processes used within The Good Docs Project.
+
+**Version:** 2.0
+
+**Last updated:** August 2020
+
+## Voting
 
 Decisions are based on voting using the following:
 
-    +1 : For
-    +0: Mildly for, but mostly indifferent
-    0: Indifferent
-    -0: Mildly against, but mostly indifferent
-    -1 : Strongly against. This is expected to be accompanied by a reason.
+*   +1 : For
+*   +0: Mildly for, but mostly indifferent
+*   0: Indifferent
+*   -0: Mildly against, but mostly indifferent
+*   -1 : Strongly against. This is expected to be accompanied by a reason.
 
-For most decisions, a motion is raised within one of TheGoodDocsProject open forums (slack, email list, etc) and those present vote and decide. Should a decision:
+## Simple decisions
 
-    Be strategic or impact many within TheGoodDocsProject,
-    Or if there is contention in deciding, and after discussion at least one member is still strongly against the motion, by continuing to vote -1,
+For most decisions, a motion is raised within one of The Good Docs Project open forums (slack, email list, weekly meeting, etc.) and those present vote and decide. 
 
-Then the motion should be referred to the PSC.
+## Significant decisions
 
-For motions presented to the PSC, a motion is considered passed when there are more PSC +1 votes than -1 votes, and either all PSC members have voted, or 4 days have passed. In the case of a tie, the PSC chair shall have 1.5 votes.
+Should a decision:
+
+*   Be of interest to others not present,
+*   Be strategic or impact many within the project,
+*   Be contentious, and after discussion at least one member is still strongly against the motion, by continuing to vote -1,
+
+then a motion should be raised as an email thread on our [general email list](https://thegooddocsproject.groups.io/g/main). The title should start: “Motion: …”
+
+All community members are encouraged to vote to demonstrate community support, however contentious motions will only count votes from PSC members.
+
+A motion is considered passed when there are more PSC +1 votes than -1 votes, and either all PSC members have voted, or 4 days have passed. In the case of a tie, the PSC chair shall have the deciding vote.
+
+## Record decisions
+
+*   All decisions should be captured in meeting minutes or forwarded to our email list. 
+*   Results of significant decisions should be copied into our [decision register](https://github.com/thegooddocsproject/governance/wiki/Decision-Log-2010).

--- a/decisions.md
+++ b/decisions.md
@@ -34,7 +34,7 @@ Should a decision:
 
 then a motion should be raised as an email thread on our [general email list](https://thegooddocsproject.groups.io/g/main). The subject line should start: “Motion: …”
 
-All community members are encouraged to vote to demonstrate community support, however contentious motions will only count votes from PSC members.
+All community members are encouraged to vote to help us reach community concensus. Should a motion be contentious only votes from PSC members will be counted. PSC are expected to advocate for the best interests of our community and consider community opinions when voting.
 
 A motion is considered passed when there are more PSC +1 votes than -1 votes, and either all PSC members have voted, or 4 days have passed. In the case of a tie, the PSC chair shall have the deciding vote.
 

--- a/decisions.md
+++ b/decisions.md
@@ -41,4 +41,4 @@ A motion is considered passed when there are more PSC +1 votes than -1 votes, an
 ## Record decisions
 
 *   All decisions should be captured in meeting minutes or forwarded to our email list. 
-*   Results of significant decisions should be copied into our [decision register](https://github.com/thegooddocsproject/governance/wiki/Decision-Log-2010).
+*   Results of significant decisions should be copied into our [decision register](https://github.com/thegooddocsproject/governance/wiki/Decision-Log-2020).

--- a/prioritization.md
+++ b/prioritization.md
@@ -23,7 +23,7 @@ We prioritize the following principles when considering budget allocation:
 *   We are wary of introducing a maintenance liability. We want material which is going to be adopted and maintained by the greater community.
 *   We look favourably on matching contributions. If someone else is prepared to sponsor your idea, it is a good indicator of worthiness.
 *   We like to help owners of useful proprietary material who wish to share it under an open license. This could be by covering the business costs of sharing, or by counting the material as an in-kind contribution.
-*   The results of any implementation, and its dependencies, must be available under the open licenses used by our project.
+*   The results of any implementation, and its dependencies, must be available under the [open licenses](/licences.html) used by our project.
 
 ## Sponsorship
 

--- a/prioritization.md
+++ b/prioritization.md
@@ -21,7 +21,7 @@ We prioritize the following principles when considering budget allocation:
 *   We like unblocking obstacles preventing the community from moving forward. Maybe a technical challenge, maybe a bunch of boring grunt work or it could be business-as-usual overheads.
 *   We prioritize ideas which are not already being solved elsewhere.
 *   We are wary of introducing a maintenance liability. We want material which is going to be adopted and maintained by the greater community.
-*   We look favourably on matching contributions. If someone else is prepared to sponsor your idea, it is a good indicator of a worthiness.
+*   We look favourably on matching contributions. If someone else is prepared to sponsor your idea, it is a good indicator of worthiness.
 *   We like to help owners of useful proprietary material who wish to share it under an open license. This could be by covering the business costs of sharing, or by counting the material as an in-kind contribution.
 *   The results of any implementation, and its dependencies, must be available under the open licenses used by our project.
 

--- a/prioritization.md
+++ b/prioritization.md
@@ -4,7 +4,7 @@ layout: default
 
 # Prioritization guidelines
 
-This document describes the principles to be considered when introducing major functionality and sponsorship for [The Good Docs Project](https://thegooddocsproject.dev/). It should be read in conjunction with our [budget approval process](budget.html).
+This document describes the principles to be considered when introducing major functionality and sponsorship for [The Good Docs Project](https://thegooddocsproject.dev/). It should be read in conjunction with our [proposal selection process](proposal-selection.html).
 
 **Version:** 1.0
 

--- a/prioritization.md
+++ b/prioritization.md
@@ -1,0 +1,39 @@
+---
+layout: default
+---
+
+# Prioritization guidelines
+
+This document describes the principles to be considered when introducing major functionality and sponsorship for [The Good Docs Project](https://thegooddocsproject.dev/). It should be read in conjunction with our [budget approval process](budget.html).
+
+**Version:** 1.0
+
+**Last updated:** August 2020
+
+## Prioritization guidelines
+
+We prioritize the following principles when considering budget allocation:
+
+*   We consider community engagement to be very important. It is an indicator of long term sustainability.
+*   We like to help the enablers within communities. These people often take on the tedious but important jobs. Or they help tackle and resolve difficult problems. They may be both old timers or fresh and enthusiastic new contributors.
+*   We prioritize ideas which have wide support from within our community forums. Ideas need to be debated within our forums and have gathered support before they will be considered for sponsorship.
+*   We prioritize high value ideas, ones which lift the collective effectiveness of our community.
+*   We like unblocking obstacles preventing the community from moving forward. Maybe a technical challenge, maybe a bunch of boring grunt work or it could be business-as-usual overheads.
+*   We prioritize ideas which are not already being solved elsewhere.
+*   We are wary of introducing a maintenance liability. We want material which is going to be adopted and maintained by the greater community.
+*   We look favourably on matching contributions. If someone else is prepared to sponsor your idea, it is a good indicator of a worthiness.
+*   We like to help owners of useful proprietary material who wish to share it under an open license. This could be by covering the business costs of sharing, or by counting the material as an in-kind contribution.
+*   The results of any implementation, and its dependencies, must be available under the open licenses used by our project.
+
+## Sponsorship
+
+*   We welcome financial sponsorship of our project.
+*   We expect our sponsors to behave ethically and uphold business practices which align with our [Code of Conduct](https://github.com/thegooddocsproject/governance/blob/master/CodeOfConduct.md).
+*   Sponsors are encouraged to extend the value of their sponsorship by engaging with our community and providing co-mentors on initiatives.
+*   Sponsors can set guidelines on how their sponsorship is spent, such as targeting specific bounty projects. These guidelines will need to align with the goals of The Good Docs Project and the greater technical writing community.
+*   Note that sponsorship influence should be used responsibly. It should promote rather than hinder the needs and values of The Good Docs Project and the wider technical writing ecosystem.
+*   We appreciate the value provided by sponsors and will show sponsors on our website.
+
+## Thanks to our contributors
+
+We acknowledge the significant value created by contributions within our community. Many people have given as volunteers. Others are paid a fraction of their worth in the marketplace. For that we are privileged and thankful. 

--- a/proposal-selection.md
+++ b/proposal-selection.md
@@ -40,7 +40,7 @@ On initiation of this process, a call for proposals will be sent to public forum
     *   You must be at least 18 years of age when you register.
     *   You must be eligible to work in the country you will reside in during the program.
     *   You must reside in a country that is not currently embargoed by the United States. See the [program rules](https://developers.google.com/season-of-docs/terms/program-rules) and the [Sanctions Programs and Country Information](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) from the US Treasury.
-*   We support diversity and encourage applications and involvement from underrepresented communities.
+*   We support diversity and encourage applications and involvement from under-represented communities.
 
 ## Implementation process
 

--- a/proposal-selection.md
+++ b/proposal-selection.md
@@ -90,7 +90,7 @@ A variant on the following process should be considered for major initiatives.
 ## Project Adjustments
 
 *   Project scope may be adjusted by mutual agreement between the mentor and proposer. 
-*   Scope changes must be approved by the mentor and PSC [decision process](decision.html).
+*   Scope changes must be approved by the mentor and PSC [decision process](decisions.html).
 *   All scope changes must be documented in writing.
 
 ## Project completion

--- a/proposal-selection.md
+++ b/proposal-selection.md
@@ -55,7 +55,7 @@ A variant on the following process should be considered for major initiatives.
 **Prepare proposal:**
 
 *   Develop a proposal in conjunction with the community. Make sure it addresses our project priorities.
-*   Find a trusted mentor from our community who is willing to mentor you.
+*   Find a trusted member of our community who is willing to mentor you.
 *   Share proposal.
 
 **Review proposals:**

--- a/proposal-selection.md
+++ b/proposal-selection.md
@@ -1,0 +1,108 @@
+---
+layout: default
+---
+
+# Proposal selection process
+
+This process is used when selecting major initiatives to incorporate into the baseline of The Good Docs Project. In particular, it is used when deciding upon proposals to sponsor.
+
+**Version:** 1.0
+
+**Last updated:** August 2020
+
+## When do we use this process?
+
+This process is initiated periodically and typically depends upon:
+
+*   Timing of current build cycles.
+*   Sufficient bandwidth available within the community.
+*   Budget availability.
+
+Timing will typically align with the [Season of Docs](https://developers.google.com/season-of-docs) schedule.
+
+## Call for proposals
+
+On initiation of this process, a call for proposals will be sent to public forums, which will at a minimum include our [announce email list](https://thegooddocsproject.groups.io/g/announce). The announcement will include references to:
+
+*   Expectations for proposals.
+*   [Prioritization guidelines](prioritization.html).
+*   Eligibility.
+*   Associated timelines.
+*   Budget availability (if applicable).
+*   How to submit the proposal.
+
+## Eligibility
+
+*   You should be actively involved in The Good Docs Project or a related community. (Note, involvement in our community is open to all.)
+*   You will need to have won the trust of this community in order to have them back your proposal.
+*   You will need a [mentor](roles.html) before you get an application approved.
+*   You should fit with the [eligibility criteria of Season of Docs:](https://developers.google.com/season-of-docs/docs/faq#what_are_the_eligibility_requirements_for_participation)
+    *   You must be at least 18 years of age when you register.
+    *   You must be eligible to work in the country you will reside in during the program.
+    *   You must reside in a country that is not currently embargoed by the United States. See the [program rules](https://developers.google.com/season-of-docs/terms/program-rules) and the [Sanctions Programs and Country Information](https://www.treasury.gov/resource-center/sanctions/Programs/Pages/Programs.aspx) from the US Treasury.
+*   We support diversity and encourage applications and involvement from underrepresented communities.
+
+## Implementation process
+
+A variant on the following process should be considered for major initiatives.
+
+**Test the waters:**
+
+*   Float an idea in our community forums.
+*   Look for feedback, interest and engagement. 
+*   If you attract significant community interest and support, and the required effort is more than is likely to be addressed by volunteers, you might consider developing a proposal for sponsored work.
+
+**Prepare proposal:**
+
+*   Develop a proposal in conjunction with the community. Make sure it addresses our project priorities.
+*   Find a trusted mentor from our community who is willing to mentor you.
+*   Share proposal.
+
+**Review proposals:**
+
+*   Community review and discuss proposals.
+*   Community decides if the proposal is worth backing, and locks in if it is.
+
+**Implementation phase:**
+
+*   The worker works according to the proposed plan.
+*   The worker checks in weekly with mentors and other collaborators.
+*   Worker provides a weekly status. This can be brief, just a few lines.
+
+**Wrap up:**
+
+*   Write a report, hand over documents and present to the community.
+*   Send an announcement to the main mailing and slack #announcements channel.
+*   Arrange for a tweet and/or blog post to be created announcing the project completion, linking to the finished work.
+
+## Payment process
+
+*   Where applicable, guidance on budget will typically be based on the [stipend amounts](https://developers.google.com/season-of-docs/docs/tech-writer-stipends) used by Season of Docs (20-30 hours per week x 3 months, or equivalent effort spread over 6 months). This will be referenced from the Request for Proposal.
+*   Payment milestones will typically be every 3 months.
+*   Payments should be correlated to milestones as github tasks. 
+*   When a milestone is reached:
+    *   The implementor should comment on the milestone task, asking the mentor for review. 
+    *   The implementor should raise an invoice with our [Open Collective account](https://opencollective.com/thegooddocsproject/expenses/new).
+    *   The mentor should review the milestone, and either approve it (by closing the issue) or reject it (by providing feedback on what is still needed to reach the milestone).
+    *   If the milestone is approved, the mentor should raise a motion with the  PSC recommending that the payment be approved.
+    *   Once approved, a treasurer (not the mentor) should approve the Open Collective invoice, and the mentor updates the decision log with payment approval.
+
+## Project Adjustments
+
+*   Project scope may be adjusted by mutual agreement between the mentor and proposer. 
+*   Scope changes must be approved by the mentor and PSC [decision process](decision.html).
+*   All scope changes must be documented in writing.
+
+## Project completion
+
+*   Projects are not considered complete until all pull requests associated with the scope of work are merged and any final project report (if part of the original project proposal) has been submitted.
+
+## Transparency
+
+*   All financial transactions will be publicly visible in our [Open Collective budget](https://opencollective.com/thegooddocsproject#section-budget), including who the money is provided to, how much was spent, and who approved the spend.
+
+## Conflict resolution
+
+*   Proposers and implementers may escalate unresolved issues to the PSC (such as lack of review, lack of communication, or discrimination).
+*   The PSC shall endeavour to address concerns raised and arbitrate fairly. 
+*   The decisions of the PSC are final.

--- a/proposal-selection.md
+++ b/proposal-selection.md
@@ -50,7 +50,7 @@ A variant on the following process should be considered for major initiatives.
 
 *   Float an idea in our community forums.
 *   Look for feedback, interest and engagement. 
-*   If you attract significant community interest and support, and the required effort is more than is likely to be addressed by volunteers, you might consider developing a proposal for sponsored work.
+*   If you attract significant community interest and support, and the required effort is more than is likely to be addressed by volunteers, develop a proposal for sponsored work.
 
 **Prepare proposal:**
 

--- a/roles.md
+++ b/roles.md
@@ -15,7 +15,7 @@ Here we define roles within The Good Docs Project, along with the eligibility, e
 Everyone contributing to, or using artifacts from, The Good Docs Project is considered part of our community. We encourage all community members to actively participate in our activities. This includes:
 
 *   Participate in our forums and vote on motions.
-*   Raise and comment on bugs.
+*   Raise and comment on issues.
 *   Suggest fixes by raising pull requests.
 
 **Access:**

--- a/roles.md
+++ b/roles.md
@@ -2,8 +2,125 @@
 layout: default
 ---
 
-### Roles
+# Roles
 
-## The Good Docs Project Steering Committee
+Here we define roles within The Good Docs Project, along with the eligibility, expectations, and responsibilities associated with these roles.
 
-*   Information about the Steering Committee can be found [here](https://github.com/thegooddocsproject/governance/blob/master/ProjectSteeringCommittee.md).
+**Version:** 2.0
+
+**Last updated:** August 2020
+
+## Community
+
+Everyone contributing to, or using artifacts from, The Good Docs Project is considered part of our community. We encourage all community members to actively participate in our activities. This includes:
+
+*   Participate in our forums and vote on motions.
+*   Raise and comment on bugs.
+*   Suggest fixes by raising pull requests.
+
+**Access:**
+
+*   Community members are granted _read_ access to our github repositories.
+
+**Expectations of community members:**
+
+*   Community members are expected to be respectful to each other, in line with our [Code of Conduct](https://github.com/thegooddocsproject/governance/blob/master/CodeOfConduct.md).
+
+## Committers
+
+A committer is a trusted community member who has additionally been given _write_ access to some or all of our github repositories.
+
+**Access:**
+
+*   Committers are granted _triage_, _maintain_ and _write_ access to the github repositories which they have contributed to.
+
+**Additional expectations of committers:**
+
+*   Understand and apply our quality guidelines.
+*   Understand and abide by our license requirements.
+*   Periodically contribute to our project over a one year period.
+
+**Eligibility:**
+
+Before being accepted for this role, a person should display the following characteristics:
+
+*   Provide sustained, valuable contributions to the project, typically for three months or more. An example demonstration of this could be:
+    *   Submit pull requests which have been accepted and merged by other committers. Typically one large, three medium, or five small pull requests over three months.
+    *   Or provide equivalent contributions to our community, such as outreach, contributing to our forums, or coordinating activities. 
+*   Express an interest in ongoing participation.
+*   Acknowledge the committer expectations.
+
+## Project Steering Committee
+
+The Project Steering Committee (PSC) is the official managing body for our project. The committee is drawn from the community and is based on merit and interest.
+
+*   We aim to attract a diverse mix of personal characteristics, reflective of the community we represent.
+*   We wish to avoid having one organisation employing a controlling proportion of the PSC.
+
+A PSC chair shall be selected from the PSC, with the only official extra duty being that they have a deciding vote in the case of a tie.
+
+**Access:**
+
+*   PSC members may be granted admin access to our github repositories if they have a need for them.
+
+**Additional expectations of PSC members:**
+
+*   Consider opinions from within our community, and advocate for the best interests of our community when making decisions.
+*   Vote according to your personal best judgment, as opposed to voting on behalf of your employer.
+*   Vote promptly (usually within days) to motions being raised.
+*   Regularly participate in project activities.
+*   Help with whatever unglamourous work that is required to keep the project moving forward.
+*   Monitor conversations within our forums and contribute constructively where appropriate.
+*   Optionally attend weekly meetings.
+
+**Eligibility:**
+
+Before being accepted for this role, a person should display the following characteristics:
+
+*   Sustained track record displaying the characteristics expected of PSC members, typically while acting as a committer within our project, typically for six months or more.
+*   Express an interest in ongoing participation.
+*   Acknowledge the PSC member expectations.
+
+## Mentors
+
+Initiatives which are funded by The Good Docs Project should have a mentor.  
+
+**Expectations of mentors:**
+
+A mentor’s responsibilities typically includes:
+
+*   Mentor a worker in developing a proposal.
+*   Facilitate making connections with other members within the community.
+*   Attend weekly meetings and provide guidance where applicable.
+*   If needed, escalate concerns to the Project Steering Committee.
+*   Review work done, and recommend the approval or rejection of the project based on work done.
+
+**Eligibility:**
+
+A mentor will typically be a member of the PSC, but may be an experienced person who is trusted by the PSC.
+
+Any conflict-of-interest the mentor may have should be stated beforehand. This could result from mentoring managers, direct reports, relatives, or close friends. The PSC will need to decide whether the conflict will negatively impact the mentoring experience.
+
+## Treasurers
+
+Treasurers are PSC members who additionally have been provided with admin access to our [financial account with Open Collective](https://opencollective.com/thegooddocsproject).
+
+**Expectations of treasurers:**
+
+*   Notify the PSC of Open Collective funding requests by [raising a motion](decisions.html).
+*   AFTER receiving approval from the PSC, approve funding requests.
+
+**Eligibility:**
+
+In order to limit the risk of misappropriation of funds, financial approval privileges should only be provided to a few long serving PSC members.
+
+# Selection of roles
+
+*   The PSC will review roles at least annually, in March, with the aims of:
+    *   Inviting active and eligible community members into relevant roles, based on our eligibility criteria.
+    *   Moving people who have been inactive for a year into a retired status, with thanks.
+    *   Selecting a PSC chair.
+*   Ad-hoc invitations may be initiated throughout the year, as needed.
+*   Retired members should expect to be welcomed back if they become active again.
+*   PSC discussions about membership will typically be conducted privately in order to respect people’s feelings.
+*   PSC selection decisions will follow our decision making process.

--- a/roles.md
+++ b/roles.md
@@ -70,7 +70,7 @@ A PSC chair shall be selected from the PSC, with the only official extra duty be
 *   Vote according to your personal best judgment, as opposed to voting on behalf of your employer.
 *   Vote promptly (usually within days) to motions being raised.
 *   Regularly participate in project activities.
-*   Help with whatever unglamourous work that is required to keep the project moving forward.
+*   Help with whatever unglamorous work that is required to keep the project moving forward.
 *   Monitor conversations within our forums and contribute constructively where appropriate.
 *   Optionally attend weekly meetings.
 

--- a/roles.md
+++ b/roles.md
@@ -21,7 +21,7 @@ Everyone contributing to, or using artifacts from, The Good Docs Project is cons
 
 **Access:**
 
-*   Community members are granted _read_ access to our github repositories.
+*   Community members have _read_ access to our github repositories (by default).
 
 **Expectations of community members:**
 

--- a/roles.md
+++ b/roles.md
@@ -17,6 +17,7 @@ Everyone contributing to, or using artifacts from, The Good Docs Project is cons
 *   Participate in our forums and vote on motions.
 *   Raise and comment on issues.
 *   Suggest fixes by raising pull requests.
+*   Comment on and review pull requests.
 
 **Access:**
 

--- a/roles.md
+++ b/roles.md
@@ -123,5 +123,5 @@ In order to limit the risk of misappropriation of funds, financial approval priv
     *   Selecting a PSC chair.
 *   Ad-hoc invitations may be initiated throughout the year, as needed.
 *   Retired members should expect to be welcomed back if they become active again.
-*   PSC discussions about membership will typically be conducted privately in order to respect people’s feelings.
+*   PSC discussions about membership will typically be conducted privately in order to respect the feelings of those being discussed.
 *   PSC selection decisions will follow our decision making process.

--- a/roles.md
+++ b/roles.md
@@ -56,7 +56,7 @@ Before being accepted for this role, a person should display the following chara
 The Project Steering Committee (PSC) is the official managing body for our project. The committee is drawn from the community and is based on merit and interest.
 
 *   We aim to attract a diverse mix of personal characteristics, reflective of the community we represent.
-*   We wish to avoid having one organisation employing a controlling proportion of the PSC.
+*   We wish to avoid having employees of any one organisation representing a controlling proportion of the PSC.
 
 A PSC chair shall be selected from the PSC, with the only official extra duty being that they have a deciding vote in the case of a tie.
 


### PR DESCRIPTION
Updates processes for: decisions, prioritization, proposal-selection, roles.
Fixes #42

As this is a significant update to processes, we should endevour to get +1 votes from all PSC members.

* Cameron Shorter (person raising this pull request, voting +1)
* Felicity Brand
* Jo Cook
* Jared Morgan
* Erin McKean
* Clarence Cromwell

Review and comments from other community members are welcomed.

Note 1: I'm hoping most feedback will be captured as a separate issue, and applied to a future version of these docs. That way we can get working processes in place, and start promoting community members into roles.

Note 2: We don't yet have a Code of Conduct Committee role. That is something which was postponed to a future version so we can get these processes in place without being blocked.

Note 3: I'm ashamed to admit that I haven't managed to get a working local environment stood up, and hence have only visually checked links in this update. It would be great if someone could check that for me.