### PR TITLE
Add link to blog link about Jo and Jared open source awards

### DIFF
--- a/press.md
+++ b/press.md
@@ -6,8 +6,9 @@ layout: default
 
 ## Announcements
 
+*   2020-09-18 [Google's Open Source Peer Bonus awards for Jared Morgan and Jo Cook](http://cameronshorter.blogspot.com/2020/09/awards-for-open-source-tech-writers.html)
 *   2020-05-27 Article about Felicity, including [her involvement in TheGoodDocsProject](https://typo3.org/article/typo3-book-report-whos-writing-the-typo3-book)
 *   2020-03-12 Insights from involvement in [Season of Docs 2019](http://cameronshorter.blogspot.com/2020/03/insights-from-mixing-writers-with-open.html).
-*   2019-12-16 Announcing TheGoodDocsProject at the Developer Relations Conference in London. Jo Cook's [blog post](https://archaeogeek.com/blog/2019/12/15/devrelcon2019/) and [slides](https://github.com/archaeogeek/devrelcon2019).
+*   2019-12-16 Announcing TheGoodDocsProject at the Developer Relations Conference in London. Jo Cook's [blog post](https://archaeogeek.com/blog/2019/12/15/devrelcon2019/), her [slides](https://github.com/archaeogeek/devrelcon2019), and [conference recording](https://devrel.net/developer-experience/inspiring-and-empowering-users-to-become-great-writers-and-why-thats-important).
 *   2019-11-25 Launching TheGoodDocsProject at WriteTheDocs - Australia conference (and conference highlights) [Cameron Shorter's blog post](http://cameronshorter.blogspot.com/2019/11/launching-thegooddocsproject.html).
 *   2019-11-11 [Announcement-1](https://github.com/thegooddocsproject/governance/wiki/Announcement-1) Fixit Workshop, at WriteTheDocs - Australia conference.


### PR DESCRIPTION
Update press page to link to a blog post about Jo and Jared's open source awards.