### PR TITLE
content(community): updated code-of-conduct link was 404

### DIFF
--- a/community.md
+++ b/community.md
@@ -13,4 +13,4 @@ layout: default
     *   [Prioritization guidelines and principles](prioritization.html)
     *   [Proposal selection process](proposal-selection.html)
     *   [Decision log](decisionlog.html)
-*   [Code of conduct](https://github.com/thegooddocsproject/governance/blob/master/CodeOfConduct.md)
+*   [Code of conduct](https://github.com/thegooddocsproject/governance/blob/master/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## Purpose / why

Currently the `Code-of-Conduct` is a `404` error page because the name of the file has changed in the governance repository.

## What changes were made?

Just updated the individual file name.

